### PR TITLE
Feat: Add saving delay progress bar

### DIFF
--- a/src/app/[...slug]/page.tsx
+++ b/src/app/[...slug]/page.tsx
@@ -6,7 +6,8 @@ type Props = {
   params: Promise<{ slug: string[] }>;
 };
 
-const TYPING_INTERVAL_SECONDS = 4;
+const TYPING_INTERVAL_SECONDS = 6;
+const PROGRESS_UPDATE_INTERVAL_MS = 50;
 
 export default function DynamicPage({ params }: Props) {
   const [path, setPath] = useState<string>("");
@@ -142,7 +143,7 @@ export default function DynamicPage({ params }: Props) {
     }
 
     // Calculate interval steps to reach 100% just before save occurs
-    const progressStep = 100 / ((TYPING_INTERVAL_SECONDS * 1000) / 100); // Update every 100ms
+    const progressStep = 100 / ((TYPING_INTERVAL_SECONDS * 1000) / PROGRESS_UPDATE_INTERVAL_MS); // Update every 50ms
 
     // Set up progress bar update
     const interval = setInterval(() => {
@@ -150,7 +151,7 @@ export default function DynamicPage({ params }: Props) {
         const newProgress = prev + progressStep;
         return newProgress > 100 ? 100 : newProgress;
       });
-    }, 100);
+    }, PROGRESS_UPDATE_INTERVAL_MS);
     setProgressInterval(interval);
 
     const timeout = setTimeout(() => {

--- a/src/app/[...slug]/page.tsx
+++ b/src/app/[...slug]/page.tsx
@@ -17,7 +17,7 @@ export default function DynamicPage({ params }: Props) {
   const [loading, setLoading] = useState<boolean>(true);
   const [typingTimeout, setTypingTimeout] = useState<NodeJS.Timeout | null>(null);
   const [isClient, setIsClient] = useState<boolean>(false);
-  const [typingProgress, setTypingProgress] = useState<number>(0);
+  const [typingProgress, setTypingProgress] = useState<number>(100);
   const [progressInterval, setProgressInterval] = useState<NodeJS.Timeout | null>(null);
 
   async function saveContent(path: string, content: string) {


### PR DESCRIPTION
### Why
It's difficult to know when the page will start saving and lock typing input

---

### What's changing
- Add a progress bar to inform about saving timeout
- Add a constant to operate typingTimeout
- Increase typingTimeout delay
